### PR TITLE
fix(site): 修复展开和收起按钮过程中代码块的滚动条出现又消失的问题

### DIFF
--- a/ex/app/shared/components/demo/demo.component.scss
+++ b/ex/app/shared/components/demo/demo.component.scss
@@ -69,6 +69,7 @@
       border: none;
       padding: 20px 15px;
       border-radius: 0;
+      overflow-y: hidden;
     }
   }
   .demo-block-control {


### PR DESCRIPTION
## PR Checklist  

- [ ] Fix linting errors
- [ ] Label has been added

## Change information

ex网站的示例代码块在收起和展开时，由于是使用transition，高度改变动画过程中`<code class="hljs">...</code>`标签的纵向滚动条会出现，并且在动画完成后消失，加入`overflow: hidden;` 使滚动条消失