### PR TITLE
feat: add alert effect input

### DIFF
--- a/ex/docs/alert.json
+++ b/ex/docs/alert.json
@@ -42,6 +42,13 @@
       "type": "EventEmitter",
       "enum": null,
       "default": null
+    },
+    {
+      "name": "effect",
+      "notes": "Choose theme",
+      "type": "string",
+      "enum": "light / dark",
+      "default": "light"
     }
   ]
 }

--- a/src/alert/alert.ts
+++ b/src/alert/alert.ts
@@ -16,7 +16,7 @@ export const ICON_CLASS_MAP: { [key: string]: string } = {
   animations: [fadeAnimation],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div [class]="'el-alert el-alert--' + type" [@fadeAnimation]="!visible"
+    <div [class]="'el-alert el-alert--' + type + ' is-' + effect" [@fadeAnimation]="!visible"
       [class.is-center]="center" role="alert">
       <i [class]="'el-alert__icon ' + makeIconClass()" *ngIf="showIcon"></i>
       <div class="el-alert__content">
@@ -41,6 +41,7 @@ export class ElAlert {
   @ContentChild('description') descriptionTmp: TemplateRef<any>
   
   @Input() type: string = 'info'
+  @Input() effect: string = 'light'
   @Input() center: boolean = false
   @Input() description: string
   @Input() closable: boolean = true


### PR DESCRIPTION
## PR Checklist  

- [ ] Fix linting errors
- [ ] Label has been added

## Change information

When using `element-theme-chalk` package, alerts don't have any backgrounds and colors depending on their type. This is due to the missing `is-light` or `is-dark` class on the alert.

This PR adds the corresponding input `effect` to set the theme of the alert (name of the input taken from the Element UI docs).